### PR TITLE
Link blog title to main site

### DIFF
--- a/pkg/handlers/templates/home.gohtml
+++ b/pkg/handlers/templates/home.gohtml
@@ -73,7 +73,7 @@
     </style>
 </head>
 <body>
-    <h1>Ashouri</h1>
+    <h1><a href="https://ashouri.xyz/" style="text-decoration: none; color: inherit;">Ashouri</a></h1>
 
     <div class="links">
         <a href="https://github.com/redscaresu" target="_blank">GitHub</a>


### PR DESCRIPTION
## Summary
- make the Ashouri headline on the blog homepage link back to https://ashouri.xyz/
