### PR TITLE
Refresh blog editorial colour scheme

### DIFF
--- a/pkg/handlers/microblog_test.go
+++ b/pkg/handlers/microblog_test.go
@@ -67,7 +67,7 @@ func TestListenAndServe_NoCache(t *testing.T) {
 	assert.Contains(t, got, "<h2><a href=\"/post/foo")
 	assert.Contains(t, got, "<p>foo</p>")
 	assert.Contains(t, got, "<p>boo</p>")
-	assert.Contains(t, got, "<h3 style=\"color: grey; font-size: 0.9em;\">1 June, 2025</h3>")
+	assert.Contains(t, got, "<h3>1 June, 2025</h3>")
 	assert.Contains(t, got, "<title>Ashouri</title>")
 	assert.Contains(t, got, ">GitHub</a>")
 	assert.Contains(t, got, ">LinkedIn</a>")
@@ -121,7 +121,7 @@ func TestListenAndServe_CacheHit(t *testing.T) {
 	assert.Contains(t, got, "<h2><a href=\"/post/foo")
 	assert.Contains(t, got, "<p>foo</p>")
 	assert.Contains(t, got, "<p>boo</p>")
-	assert.Contains(t, got, "<h3 style=\"color: grey; font-size: 0.9em;\">1 June, 2025</h3>")
+	assert.Contains(t, got, "<h3>1 June, 2025</h3>")
 
 	// test cache hit
 	resp, err = http.Get(server.URL)
@@ -137,7 +137,7 @@ func TestListenAndServe_CacheHit(t *testing.T) {
 	assert.Contains(t, got, "<h2><a href=\"/post/foo")
 	assert.Contains(t, got, "<p>foo</p>")
 	assert.Contains(t, got, "<p>boo</p>")
-	assert.Contains(t, got, "<h3 style=\"color: grey; font-size: 0.9em;\">1 June, 2025</h3>")
+	assert.Contains(t, got, "<h3>1 June, 2025</h3>")
 }
 
 func TestHealthz(t *testing.T) {

--- a/pkg/handlers/templates/blogpost.gohtml
+++ b/pkg/handlers/templates/blogpost.gohtml
@@ -5,40 +5,49 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.TitleNonHTML}}</title>
     <style>
+        :root {
+            --paper: #f5f0e6;
+            --ink: #202829;
+            --muted: #626a68;
+            --line: #cfc5b6;
+            --accent: #9a3f2b;
+            --quote: #ebe2d5;
+        }
+
         body {
-            font-family: Arial, sans-serif;
-            background-color: #0d1b2a; /* Darker blue background */
-            color: #ffffff; /* White text color */
+            font-family: Georgia, "Times New Roman", serif;
+            background-color: var(--paper);
+            color: var(--ink);
             margin: 0;
-            padding: 0;
+            padding: 0 1rem 4rem;
         }
 
         .container {
-            max-width: 800px; /* Limit the width of the content */
-            margin: 40px auto; /* Center the content and add vertical spacing */
-            padding: 20px; /* Add padding inside the container */
-            background-color: #1b263b; /* Slightly lighter background for contrast */
-            border-radius: 8px; /* Rounded corners for a modern look */
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); /* Subtle shadow for depth */
+            max-width: 760px;
+            margin: 2.5rem auto;
+            padding-top: 1.75rem;
+            border-top: 1px solid var(--line);
         }
 
         h1 {
-            text-align: center;
-            margin-top: 20px;
-            color: #e94560; /* Accent color for the title */
+            margin: 0 0 1.5rem;
+            color: var(--ink);
+            font-size: clamp(2.1rem, 6vw, 3.5rem);
+            font-weight: 400;
+            line-height: 1.08;
+            letter-spacing: 0;
         }
 
         blockquote {
-            margin: 20px 0; /* Add vertical spacing */
-            padding: 10px 20px; /* Add padding inside the blockquote */
-            border-left: 4px solid #e94560; /* Add a colored border to the left */
-            background-color: #2e3b4e; /* Slightly darker background for contrast */
-            color: #ffffff; /* White text color */
-            font-style: italic; /* Italicize the text */
+            margin: 1.5rem 0;
+            padding: 1rem 1.25rem;
+            border-left: 4px solid var(--accent);
+            background-color: var(--quote);
+            font-style: italic;
         }
 
         a {
-            color: #0fbcf9; /* Light blue color for links */
+            color: var(--accent);
             text-decoration: none;
         }
 
@@ -47,13 +56,15 @@
         }
 
         p {
-            color: #ffffff; /* White text color for paragraphs */
-            line-height: 1.8; /* Improve readability with increased line height */
+            color: var(--ink);
+            line-height: 1.8;
         }
 
         .back-link {
-            text-align: center;
-            margin: 20px 0;
+            max-width: 760px;
+            margin: 1.5rem auto 0;
+            font-family: Arial, sans-serif;
+            font-size: 0.95rem;
         }
     </style>
 </head>

--- a/pkg/handlers/templates/home.gohtml
+++ b/pkg/handlers/templates/home.gohtml
@@ -23,7 +23,7 @@
         }
 
         .container {
-            width: min(760px, 100%);
+            width: min(660px, 100%);
             margin: 2.75rem auto 0;
             border-top: 1px solid var(--line);
             border-bottom: 1px solid var(--line);
@@ -79,6 +79,10 @@
             margin: 0;
         }
 
+        .post-preview {
+            font-size: 1.05rem;
+        }
+
         .about-me {
             text-align: center;
             margin: 1.5rem 0 0;
@@ -121,7 +125,7 @@
             <div class="blog-post">
                 <h3>{{.FormattedDate}}</h3>
                 <h2><a href="/post/{{urlquery .Name}}">{{.Title}}</a></h2>
-                <div>{{.Content | truncateChars 300}}</div>
+                <div class="post-preview">{{.Content | truncateChars 420}}</div>
             </div>
         {{ end }}
     </div>

--- a/pkg/handlers/templates/home.gohtml
+++ b/pkg/handlers/templates/home.gohtml
@@ -5,27 +5,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ashouri</title>
     <style>
+        :root {
+            --paper: #f5f0e6;
+            --ink: #202829;
+            --muted: #626a68;
+            --line: #cfc5b6;
+            --accent: #9a3f2b;
+            --accent-dark: #6f2d1f;
+        }
+
         body {
-            font-family: Arial, sans-serif;
-            background-color: #0d1b2a; /* Dark blue background */
-            color: #ffffff; /* White text color */
+            font-family: Georgia, "Times New Roman", serif;
+            background-color: var(--paper);
+            color: var(--ink);
             margin: 0;
-            padding: 0;
+            padding: 0 1rem 4rem;
         }
 
         .container {
-            width: 80%;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #0d1b2a; /* Slightly lighter dark blue */
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-            border-radius: 8px; /* Rounded corners */
+            width: min(760px, 100%);
+            margin: 2.75rem auto 0;
+            border-top: 1px solid var(--line);
+            border-bottom: 1px solid var(--line);
         }
 
         .blog-post {
-            border-bottom: 1px solid #ddd;
-            padding: 10px 0;
-            text-align: center;
+            border-bottom: 1px solid var(--line);
+            padding: 1.5rem 0;
         }
 
         .blog-post:last-child {
@@ -34,12 +40,32 @@
 
         h1 {
             text-align: center;
-            margin-top: 20px;
-            color: #e94560; /* Accent color for the title */
+            margin: 2rem 0 0.75rem;
+            color: var(--ink);
+            font-size: clamp(2.4rem, 8vw, 4.5rem);
+            font-weight: 400;
+            letter-spacing: 0;
+        }
+
+        h2 {
+            margin: 0.35rem 0 0.75rem;
+            font-size: clamp(1.45rem, 4vw, 2.25rem);
+            font-weight: 400;
+            line-height: 1.1;
+        }
+
+        h3 {
+            margin: 0;
+            color: var(--muted);
+            font-family: Arial, sans-serif;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
         }
 
         a {
-            color: #0fbcf9; /* Light blue color for links */
+            color: var(--accent);
             text-decoration: none;
         }
 
@@ -48,22 +74,28 @@
         }
 
         p {
-            color: #ffffff; /* White text color for paragraphs */
+            color: var(--ink);
+            line-height: 1.7;
+            margin: 0;
         }
 
         .about-me {
             text-align: center;
-            margin: 20px 0;
+            margin: 1.5rem 0 0;
+            color: var(--muted);
+            font-family: Arial, sans-serif;
+            font-size: 0.95rem;
         }
 
         .links {
             text-align: center;
-            margin-bottom: 20px;
+            margin-bottom: 1.5rem;
+            font-family: Arial, sans-serif;
         }
 
         .links a {
-            margin: 0 10px;
-            color: #0fbcf9;
+            margin: 0 0.5rem;
+            color: var(--accent-dark);
             text-decoration: none;
         }
 
@@ -87,7 +119,7 @@
         <!-- Blog posts will be displayed here -->
         {{ range .}}
             <div class="blog-post">
-                <h3 style="color: grey; font-size: 0.9em;">{{.FormattedDate}}</h3> <!-- Smaller and grey -->
+                <h3>{{.FormattedDate}}</h3>
                 <h2><a href="/post/{{urlquery .Name}}">{{.Title}}</a></h2>
                 <div>{{.Content | truncateChars 300}}</div>
             </div>


### PR DESCRIPTION
## Summary
- replace the blog's dark cyan/red palette with a quieter Ashouri editorial palette
- update homepage and post templates to use warm paper, dark ink, muted borders, and rust links
- update handler assertions for the date markup after removing inline styling

## Verification
- go test ./pkg/handlers
- npm run test:e2e
