### PR TITLE
Restore professional consultancy theme

### DIFF
--- a/pkg/handlers/templates/blogpost.gohtml
+++ b/pkg/handlers/templates/blogpost.gohtml
@@ -7,23 +7,22 @@
     <link rel="icon" href="/assets/ashouri-favicon.svg" type="image/svg+xml">
     <style>
         :root {
-            --bg: #081111;
-            --panel: rgba(16, 26, 26, 0.9);
-            --ink: #e8f0e8;
-            --muted: #91a39c;
-            --line: #263939;
-            --line-strong: #3c5552;
-            --accent: #49e58f;
-            --quote: #101a1a;
+            --paper: #f5f0e6;
+            --panel: rgba(255, 252, 247, 0.82);
+            --ink: #202829;
+            --muted: #626a68;
+            --line: #cfc5b6;
+            --accent: #9a3f2b;
+            --quote: #ebe2d5;
         }
 
         body {
-            font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            font-family: Georgia, "Times New Roman", serif;
             background:
-                linear-gradient(rgba(73, 229, 143, 0.035) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(73, 229, 143, 0.035) 1px, transparent 1px),
-                radial-gradient(circle at 50% -12rem, rgba(73, 229, 143, 0.16), transparent 34rem),
-                var(--bg);
+                linear-gradient(rgba(32, 40, 41, 0.035) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(32, 40, 41, 0.035) 1px, transparent 1px),
+                radial-gradient(circle at 50% -12rem, rgba(154, 63, 43, 0.14), transparent 34rem),
+                var(--paper);
             background-size: 28px 28px, 28px 28px, auto, auto;
             color: var(--ink);
             margin: 0;
@@ -36,15 +35,16 @@
             padding: 1.75rem;
             border: 1px solid var(--line);
             background: var(--panel);
+            backdrop-filter: blur(10px);
         }
 
         h1 {
             margin: 0 0 1.5rem;
             color: var(--ink);
             font-size: clamp(2.1rem, 6vw, 3.5rem);
-            font-weight: 750;
+            font-weight: 400;
             line-height: 1.08;
-            letter-spacing: -0.05em;
+            letter-spacing: 0;
         }
 
         blockquote {
@@ -53,6 +53,7 @@
             border-left: 4px solid var(--accent);
             background-color: var(--quote);
             color: var(--ink);
+            font-style: italic;
         }
 
         a {

--- a/pkg/handlers/templates/editpost.gohtml
+++ b/pkg/handlers/templates/editpost.gohtml
@@ -8,20 +8,20 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
     <style>
         :root {
-            --bg: #081111;
-            --panel: #101a1a;
-            --ink: #e8f0e8;
-            --muted: #91a39c;
-            --line: #263939;
-            --accent: #49e58f;
+            --paper: #f5f0e6;
+            --panel: #fffaf2;
+            --ink: #202829;
+            --muted: #626a68;
+            --line: #cfc5b6;
+            --accent: #9a3f2b;
         }
 
         body {
             font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
             background:
-                linear-gradient(rgba(73, 229, 143, 0.035) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(73, 229, 143, 0.035) 1px, transparent 1px),
-                var(--bg);
+                linear-gradient(rgba(32, 40, 41, 0.035) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(32, 40, 41, 0.035) 1px, transparent 1px),
+                var(--paper);
             background-size: 28px 28px, 28px 28px, auto;
             color: var(--ink);
             margin: 0;
@@ -40,7 +40,7 @@
             margin-top: 20px;
             padding: 20px;
             border: 1px solid var(--line);
-            background-color: rgba(8, 17, 17, 0.5);
+            background-color: rgba(255, 252, 247, 0.72);
         }
 
         .edit-post input, .edit-post textarea {
@@ -49,14 +49,14 @@
             margin: 10px 0;
             border: 1px solid var(--line);
             border-radius: 4px;
-            background: #050909;
+            background: #fff;
             color: var(--ink);
         }
 
         .edit-post button {
             padding: 10px 20px;
             background-color: var(--accent);
-            color: #071010;
+            color: #fffaf2;
             border: 1px solid var(--accent);
             border-radius: 4px;
             cursor: pointer;
@@ -64,7 +64,7 @@
         }
 
         .edit-post button:hover {
-            background-color: #73f0a9;
+            background-color: #6f2d1f;
         }
 
         h1 {

--- a/pkg/handlers/templates/home.gohtml
+++ b/pkg/handlers/templates/home.gohtml
@@ -13,23 +13,22 @@
         }
 
         :root {
-            --bg: #081111;
-            --panel: rgba(16, 26, 26, 0.9);
-            --ink: #e8f0e8;
-            --muted: #91a39c;
-            --line: #263939;
-            --line-strong: #3c5552;
-            --accent: #49e58f;
-            --accent-dark: #9dd6ff;
+            --paper: #f5f0e6;
+            --panel: rgba(255, 252, 247, 0.78);
+            --ink: #202829;
+            --muted: #626a68;
+            --line: #cfc5b6;
+            --accent: #9a3f2b;
+            --accent-dark: #6f2d1f;
         }
 
         body {
-            font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            font-family: Georgia, "Times New Roman", serif;
             background:
-                linear-gradient(rgba(73, 229, 143, 0.035) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(73, 229, 143, 0.035) 1px, transparent 1px),
-                radial-gradient(circle at 50% -12rem, rgba(73, 229, 143, 0.16), transparent 34rem),
-                var(--bg);
+                linear-gradient(rgba(32, 40, 41, 0.035) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(32, 40, 41, 0.035) 1px, transparent 1px),
+                radial-gradient(circle at 50% -12rem, rgba(154, 63, 43, 0.14), transparent 34rem),
+                var(--paper);
             background-size: 28px 28px, 28px 28px, auto, auto;
             color: var(--ink);
             margin: 0;
@@ -41,6 +40,7 @@
             margin: 2.75rem auto 0;
             border: 1px solid var(--line);
             background: var(--panel);
+            backdrop-filter: blur(10px);
         }
 
         .blog-post {
@@ -72,10 +72,29 @@
         h1 a::after {
             content: "";
             display: block;
-            width: 2.8em;
+            width: 0.58em;
             height: 0.08em;
             margin-top: 0.16em;
             background: var(--accent);
+            animation: terminal-cursor-blink 1s steps(1, end) infinite;
+        }
+
+        @keyframes terminal-cursor-blink {
+            0%,
+            48% {
+                opacity: 1;
+            }
+
+            49%,
+            100% {
+                opacity: 0;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            h1 a::after {
+                animation: none;
+            }
         }
 
         h2 {

--- a/pkg/handlers/templates/newpost.gohtml
+++ b/pkg/handlers/templates/newpost.gohtml
@@ -7,20 +7,20 @@
     <link rel="icon" href="/assets/ashouri-favicon.svg" type="image/svg+xml">
     <style>
         :root {
-            --bg: #081111;
-            --panel: #101a1a;
-            --ink: #e8f0e8;
-            --muted: #91a39c;
-            --line: #263939;
-            --accent: #49e58f;
+            --paper: #f5f0e6;
+            --panel: #fffaf2;
+            --ink: #202829;
+            --muted: #626a68;
+            --line: #cfc5b6;
+            --accent: #9a3f2b;
         }
 
         body {
             font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
             background:
-                linear-gradient(rgba(73, 229, 143, 0.035) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(73, 229, 143, 0.035) 1px, transparent 1px),
-                var(--bg);
+                linear-gradient(rgba(32, 40, 41, 0.035) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(32, 40, 41, 0.035) 1px, transparent 1px),
+                var(--paper);
             background-size: 28px 28px, 28px 28px, auto;
             color: var(--ink);
             margin: 0;
@@ -39,7 +39,7 @@
             margin-top: 20px;
             padding: 20px;
             border: 1px solid var(--line);
-            background-color: rgba(8, 17, 17, 0.5);
+            background-color: rgba(255, 252, 247, 0.72);
         }
 
         .new-post input, .new-post textarea {
@@ -48,14 +48,14 @@
             margin: 10px 0;
             border: 1px solid var(--line);
             border-radius: 4px;
-            background: #050909;
+            background: #fff;
             color: var(--ink);
         }
 
         .new-post button {
             padding: 10px 20px;
             background-color: var(--accent);
-            color: #071010;
+            color: #fffaf2;
             border: 1px solid var(--accent);
             border-radius: 4px;
             cursor: pointer;
@@ -63,7 +63,7 @@
         }
 
         .new-post button:hover {
-            background-color: #73f0a9;
+            background-color: #6f2d1f;
         }
 
         h1 {


### PR DESCRIPTION
## Summary
- move the blog back from the dark ops-console styling to the warmer Ashouri editorial palette
- keep subtle technical cues via a faint grid texture, monospace metadata/links, and the blinking A underline
- update public and admin templates for visual consistency

## Tests
- go test ./...
